### PR TITLE
Handle sql comments

### DIFF
--- a/src/SqlParser.jison
+++ b/src/SqlParser.jison
@@ -11,6 +11,7 @@
 
 %%
 
+[/][*].*?[*][/]                                  /* skip comments */
 [a-zA-Z_][a-zA-Z0-9_]*\.[a-zA-Z_][a-zA-Z0-9_]*   return 'QUALIFIED_IDENTIFIER'
 [a-zA-Z_][a-zA-Z0-9_]*\.\*                       return 'QUALIFIED_STAR'
 \s+                                              /* skip whitespace */


### PR DESCRIPTION
Ideally I'd like to allow sql comments anywhere in the grammer and pass them through untouched, but I couldn't figure out how to do that.  For now this will ignore (strip out) sql comments instead of causing parsing errors.

If you have any ideas how to pass through sql comments anywhere in the grammar let me know and I'll try it out.

Thanks,
Trask
