### PR TITLE
Support quoted identifiers

### DIFF
--- a/src/SqlParser.jison
+++ b/src/SqlParser.jison
@@ -74,6 +74,7 @@ N?['](\\.|[^'])*[']                              return 'STRING'
 (true|false)                                     return 'BOOLEAN'
 [0-9]+(\.[0-9]+)?                                return 'NUMERIC'
 [a-zA-Z_][a-zA-Z0-9_]*                           return 'IDENTIFIER'
+["][a-zA-Z_][a-zA-Z0-9_]*["]                     return 'QUOTED_IDENTIFIER'
 [?]                                              return 'BIND'
 <<EOF>>                                          return 'EOF'
 .                                                return 'INVALID'
@@ -354,6 +355,7 @@ factor
 term
     : value { $$ = {nodeType: 'Term', value: $1}; }
     | IDENTIFIER { $$ = {nodeType: 'Term', value: $1}; }
+    | QUOTED_IDENTIFIER { $$ = {nodeType: 'Term', value: $1}; }
     | QUALIFIED_IDENTIFIER { $$ = {nodeType: 'Term', value: $1}; }
     | caseWhen { $$ = $1; }
     | LPAREN expressionPlus RPAREN { $$ = {nodeType: 'Term', value: $2}; }
@@ -364,6 +366,7 @@ term
 
 dataType
     : IDENTIFIER optDataTypeLength { $$ = {name: $1, len: $2}; }
+    | QUOTED_IDENTIFIER optDataTypeLength { $$ = {name: $1, len: $2}; }
     ;
 
 optDataTypeLength


### PR DESCRIPTION
E.g.

```
select CAST(1 as "varchar"(10))
```

and

```
select DATEDIFF("day", date1, date2)
```

Probably need to support quoted identifiers in more places, but these are the only two I've run into so far.
