### PR TITLE
Fix missing NOT when formatting NOT IN

### DIFF
--- a/web/js/parser/SqlPrettyPrinter.js
+++ b/web/js/parser/SqlPrettyPrinter.js
@@ -368,11 +368,13 @@ var SqlPrettyPrinter = {
       }
       this.formatOperand(node.value, driver)
     } else if (node.nodeType == 'RhsInSelect') {
+      if (node.not) driver.writeKeyword('NOT')
       driver.writeKeyword('IN')
       driver.openParen()
       this.formatSelect(node.value, driver)
       driver.closeParen()
     } else if (node.nodeType == 'RhsInExpressionList') {
+      if (node.not) driver.writeKeyword('NOT')
       driver.writeKeyword('IN')
       driver.openParen()
       for (var i = 0; i < node.value.length; i++) {


### PR DESCRIPTION
This project is still working great!  Just ran across an issue:

```
select * from x where y not in (1, 2)
```

was being formatted as

```
SELECT *
  FROM x
 WHERE y IN (1, 2)
```

(missing the NOT keyword)
